### PR TITLE
Update to GNOME 49 runtime

### DIFF
--- a/io.github.nokse22.minitext.json
+++ b/io.github.nokse22.minitext.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.nokse22.minitext",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "49",
     "sdk" : "org.gnome.Sdk",
     "command" : "mini-text",
     "finish-args" : [


### PR DESCRIPTION
This change bumps the runtime to the new GNOME 49 runtime, as 47 is going to be unsupported soon. 
In my testing I did not notice any breakage.